### PR TITLE
修复了 Bot.pyi 中函数名字错误

### DIFF
--- a/nonebot/adapters/mirai2/bot.pyi
+++ b/nonebot/adapters/mirai2/bot.pyi
@@ -99,8 +99,8 @@ class Bot(BaseBot):
             * ``target: int`` 群 id
         """
         ...
-
-    async def bot_pro_file(self):
+        
+    async def bot_profile(self):
         """
         :说明:
 
@@ -111,8 +111,8 @@ class Bot(BaseBot):
             * 无
         """
         ...
-
-    async def friend_pro_file(self, *, target: int):
+        
+    async def friend_profile(self, *, target: int):
         """
         :说明:
 
@@ -121,6 +121,18 @@ class Bot(BaseBot):
         :参数:
 
             * ``target: int`` 好友 id
+        """
+        ...
+        
+    async def user_profile(self, *, target: int):
+        """
+        :说明:
+
+            获取QQ用户 target 的资料
+
+        :参数:
+
+            * ``target: int`` 用户 id
         """
         ...
 


### PR DESCRIPTION
很奇怪.jpg
但是最新版的 mirai-api-http，里面部分 API 的名字已经不是原先那个了
现在是
bot_profile
friend_profile

而不是
bot_pro_file
friend_pro_file